### PR TITLE
:recycle: Rename AutoInstantiable to AutoStructurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ print(request)
 
 ## Traits
 
-You can use the following traits to extend the functionality of your classes:
+You can use the following traits to extend the functionality of this library:
 
-- [AutoInstantiable](src/python_middlewareable/traits/auto_instantiable)
+- [AutoStructurable](src/python_middlewareable/traits/auto_structurable)
 - [DataStructurable](src/python_middlewareable/traits/data_structurable)
 
 ## License

--- a/jupyter/03-trait-auto-structurable.ipynb
+++ b/jupyter/03-trait-auto-structurable.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Trait `AutoInstantiable`"
+    "# Trait `AutoStructurable`"
    ]
   },
   {
@@ -32,7 +32,7 @@
     "    RequestDataBase,\n",
     "    ResponseDataBase,\n",
     "    TransportDataBase,\n",
-    "    AutoInstantiable,\n",
+    "    AutoStructurable,\n",
     ")\n",
     "\n",
     "\n",
@@ -82,14 +82,14 @@
     "        return result\n",
     "\n",
     "\n",
-    "# add `AutoInstantiable` to the middlewareable\n",
+    "# add `AutoStructurable` to the middlewareable\n",
     "class App(\n",
-    "    AutoInstantiable[Request, ResponseData, TransportDataBase],\n",
+    "    AutoStructurable[Request, ResponseData, TransportDataBase],\n",
     "    MiddlewareableBase[Request],\n",
     "):\n",
     "    middlewares = [OneMiddleware, TwoMiddleware]\n",
     "\n",
-    "    # same classes passed to \"AutoInstantiable\" above\n",
+    "    # same classes passed to \"AutoStructurable\" above\n",
     "    request_class = Request\n",
     "    response_data_class = ResponseData\n",
     "    transport_data_class = TransportDataBase\n",

--- a/src/python_middlewareable/__init__.py
+++ b/src/python_middlewareable/__init__.py
@@ -15,7 +15,7 @@ from .traits.data_structurable.dtos.response_data import (
 from .traits.data_structurable.dtos.transport_data import (
     TransportData as TransportDataBase,
 )
-from .traits.auto_instantiable.auto_instantiable import AutoInstantiable
+from .traits.auto_structurable.auto_structurable import AutoStructurable
 
 # Version of the package
 # DO NOT MODIFY MANUALLY
@@ -36,6 +36,6 @@ __all__ = [
     "RequestDataBase",
     "ResponseDataBase",
     "TransportDataBase",
-    # `AutoInstantiable` trait
-    "AutoInstantiable",
+    # `AutoStructurable` trait
+    "AutoStructurable",
 ]

--- a/src/python_middlewareable/traits/auto_structurable/auto_structurable.py
+++ b/src/python_middlewareable/traits/auto_structurable/auto_structurable.py
@@ -8,7 +8,7 @@ from ..data_structurable.dtos.transport_data import TTransportData
 from ..data_structurable.mixins.request_mixin import TRequest
 
 
-class AutoInstantiable(
+class AutoStructurable(
     DataStructurable,
     Generic[TRequest, TResponseData, TTransportData],
 ):

--- a/tests/test_trait_autostructurable.py
+++ b/tests/test_trait_autostructurable.py
@@ -8,19 +8,19 @@ from tests.stubs.fake_datastructurable_trait import (
 from python_middlewareable import (
     MiddlewareableBase,
     TransportDataBase,
-    AutoInstantiable,
+    AutoStructurable,
 )
 
 
 @pytest.mark.asyncio
-async def test_trait_autoinstantiable_instructions():
+async def test_trait_autostructurable_instructions():
     class App(
-        AutoInstantiable[Request, ResponseData, TransportDataBase],
+        AutoStructurable[Request, ResponseData, TransportDataBase],
         MiddlewareableBase[Request],
     ):
         middlewares = [OneMiddleware]
 
-        # same classes passed to "AutoInstantiable" above
+        # same classes passed to "AutoStructurable" above
         request_class = Request
         response_data_class = ResponseData
         transport_data_class = TransportDataBase


### PR DESCRIPTION
- Refactored the class name from `AutoInstantiable` to `AutoStructurable` to better reflect its purpose.
- Updated all references to the class name across the codebase for consistency.
- Improved code readability and clarity by using a more descriptive class name.