### PR TITLE
:construction_worker: Add GitHub Actions workflow for running pytest

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,8 @@
         "GitHub.copilot-chat",
         "mikestead.dotenv",
         "ms-python.flake8",
-        "tamasfe.even-better-toml"
+        "tamasfe.even-better-toml",
+        "github.vscode-github-actions"
       ],
       "settings": {
         "terminal.integrated.shell.linux": "/bin/bash",

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-on: ['push', 'pull_request']
+on: ['pull_request']
 
 jobs:
   test:
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]  # Define OS you want to test
-        python-version: [3.7, 3.11]  # Define Python versions you want to test
+        python-version: [3.8, 3.9, 3.10, 3.11]  # Define Python versions you want to test
 
     name: P${{ matrix.python-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']  # Wrapped versions in quotes
+        python-version: ['3.9', '3.10', '3.11']  # Wrapped versions in quotes
 
     name: Python ${{ matrix.python-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,9 +9,9 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python: [3.8, 3.9, 3.10, 3.11]
 
-    name: Python ${{ matrix.python-version }} - ${{ matrix.os }}
+    name: Python ${{ matrix.python }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}  # Updated to use matrix.python
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,33 @@
+name: Run Tests
+
+on: ['push', 'pull_request']
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest]  # Define OS you want to test
+        python-version: [3.7, 3.11]  # Define Python versions you want to test
+
+    name: P${{ matrix.python-version }} - ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f pyproject.toml ]; then pip install .[dev]; fi
+
+      - name: Run tests
+        run: |
+          pytest --cov  # Run pytest with coverage if needed

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,9 +9,9 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python: [3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.8', '3.9', '3.10', '3.11']  # Wrapped versions in quotes
 
-    name: Python ${{ matrix.python }} - ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}  # Updated to use matrix.python
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]  # Define OS you want to test
-        python-version: [3.8, 3.9, 3.10, 3.11]  # Define Python versions you want to test
+        os: [ubuntu-latest]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
-    name: P${{ matrix.python-version }} - ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -33,7 +32,7 @@ keywords = [
     "python-middleware",
 ]
 dependencies = []
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.optional-dependencies]
 build = ["build", "twine"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 line-length = 79
 
 [build-system]
-requires = ["setuptools>=70.0.0", "wheel"]
+requires = ["setuptools>=68.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,15 @@ requires-python = ">=3.7"
 
 [project.optional-dependencies]
 build = ["build", "twine"]
-dev = ["black", "bumpver", "isort", "flake8", "pytest"]
+dev = [
+    "black",
+    "bumpver",
+    "isort",
+    "flake8",
+    "pytest",
+    "pytest-cov",
+    "pytest-asyncio",
+]
 
 [project.urls]
 repository = "https://github.com/thecodecrate/python-middlewareable"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -32,7 +31,7 @@ keywords = [
     "python-middleware",
 ]
 dependencies = []
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 build = ["build", "twine"]

--- a/tests/test_middlewareable.py
+++ b/tests/test_middlewareable.py
@@ -2,10 +2,26 @@ import pytest
 from _pytest.capture import CaptureFixture
 from python_middlewareable import MiddlewareableBase
 from tests.stubs.fake_basic_middlewares import (
+    MiddlewareBase,
     Request,
     OneMiddleware,
     TwoMiddleware,
 )
+
+
+@pytest.mark.asyncio
+async def test_default_middleware():
+    class MyMiddleware(MiddlewareBase[Request]):
+        pass
+
+    class App(MiddlewareableBase[Request]):
+        middlewares = [MyMiddleware]
+
+    app = App()
+
+    result = await app.process_middlewares(Request(value="Hello"))
+
+    assert result.value == "Hello"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Set up GitHub Actions to automatically run `pytest` on pushes and pull requests for the `main` and `chore/pypi-release` branches.
- Configured a testing matrix to run tests on Python versions 3.7 through 3.11.
- Integrated dependency installation using `requirements.txt` or `pyproject.toml` (if present).
- Added steps to checkout code, set up Python environments, and run pytest with coverage.